### PR TITLE
FIX installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To install rdifWeb, you need to install the the prerequisites. On Debian distrib
 Then you may download a snapshot of the repository and proceed with the installation on your system.
 
     wget --no-check-certificate -O rdiffweb.tar.gz https://github.com/ikus060/rdiffweb/archive/develop.tar.gz
-    tar zxf ikus060-rdiffweb.tar.gz
+    tar zxf rdiffweb.tar.gz
     cd rdiffweb-*
     python setup.py build
     sudo python setup.py install


### PR DESCRIPTION
**[English version below]**
Ce correctif supprime une coquille des instructions d'installation : l'invocation de `tar` se fait désormais sur l'archive fraîchement téléchargée.

**[English version]**
This patch fixes a typo in the installation instructions. The `tar` command now targets the just downloaded archive.