### PR TITLE
Fix prefix matching.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Release under GPLv3
 
 To install rdifWeb, you need to install the the prerequisites. On Debian distribution you may proceed as follow.
 
-    sudo apt-get install python-cherrypy3 python-pysqlite2 libsqlite3-dev python-jinja2 python-setuptools python-babel
+    sudo apt-get install python-cherrypy3 python-pysqlite2 libsqlite3-dev python-jinja2 python-setuptools python-babel rdiff-backup 
 
 Then you may download a snapshot of the repository and proceed with the installation on your system.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Then you may download a snapshot of the repository and proceed with the installa
     cd rdiffweb-*
     python setup.py build
     sudo python setup.py install
+    
+    sudo update-rc.d rdiffweb defaults
   
 Start rdiffweb server using this command line.
 

--- a/rdiffweb/page_main.py
+++ b/rdiffweb/page_main.py
@@ -39,7 +39,7 @@ class rdiffPage:
         '''Takes a path relative to the user's root dir and validates that it
         is valid and within the user's root'''
         assert isinstance(path_b, str)
-        path_b = path_b.strip(b"/")
+        path_b = path_b.strip(b"/")+b"/"
 
         # NOTE: a blank path is allowed, since the user root directory might be
         # a repository.
@@ -52,7 +52,7 @@ class rdiffPage:
 
         # Check if any of the repos matches the given path.
         user_repos_matches = filter(
-            lambda x: path_b.startswith(encode_s(x).strip(b"/")),
+            lambda x: path_b.startswith(encode_s(x).strip(b"/")+b"/"),
             user_repos)
         if not user_repos_matches:
             # No repo matches


### PR DESCRIPTION
Prefix path matching was broken, i.e. a mount path

/blah

would conflict with

/blahblub

in that the rdiffweb would search for a subirectory blub within blah.
The current commit fixes the issue by appending a / to all prefix path
components during pattern matching.