### PR TITLE
Update rdw.conf

### DIFF
--- a/rdw.conf
+++ b/rdw.conf
@@ -37,8 +37,8 @@ Environment=production
 # The time of day when notification emails are sent out. (Default: 23:00).
 #EmailNotificationTime=23:00 
 
-# The SMTP server name (Required).
-#EmailHost=smtp.server.com
+# The SMTP server name and port (Required).
+#EmailHost=smtp.server.com:25
 
 # Encryption to be use if Any. Option: ssl or starttls (Default: none).
 #EmailEncryption=none


### PR DESCRIPTION
An email server port is missing, this causes emails not to be sent. If you do not set a port you will see the following error:

[2019-12-30 09:45:46,900][WARNING][10.7.7.14][none][CP Server Thread-13][rdiffweb.core.user] IUserChangeListener [NotificationPlugin] fail to run [user_password_changed]
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/rdiffweb/core/user.py", line 575, in _notify
    getattr(listener, mod)(*args)
  File "/usr/local/lib/python2.7/dist-packages/rdiffweb/core/notification.py", line 184, in user_password_changed
    self.send_mail(userobj, _("Password changed"), "password_changed.html")
  File "/usr/local/lib/python2.7/dist-packages/rdiffweb/core/notification.py", line 260, in send_mail
    conn = smtplib.SMTP(self._email_host, self._email_port)
  File "/usr/local/lib/python2.7/dist-packages/rdiffweb/core/config.py", line 94, in __get__
    return self.get(instance)
  File "/usr/local/lib/python2.7/dist-packages/rdiffweb/core/config.py", line 115, in get
    return self._get_func(value)
  File "/usr/local/lib/python2.7/dist-packages/rdiffweb/core/notification.py", line 122, in <lambda>
    _email_port = Option('EmailHost', _get_func=lambda x: int(x.partition(':')[2]))
ValueError: invalid literal for int() with base 10: ''