### PR TITLE
Update nginx configuration

### DIFF
--- a/doc/networking.md
+++ b/doc/networking.md
@@ -86,6 +86,7 @@ no way a complete reference.
                 proxy_set_header X-Real-IP $remote_addr;
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
                 proxy_set_header X-Forwarded-Host $server_name;
+                proxy_set_header X-Forwarded-Proto $scheme;
                 # Proxy
                 proxy_pass http://127.0.0.1:8080/;
         }


### PR DESCRIPTION
Without the X-Forwarded-Proto header, the wrong protocol gets passed to the rdiffweb server, eventually producing a mixed content situation, where the static linked resourced get passed through HTTP instead of HTTPS, preventing the CSSs and the JSs from being loaded.
Very similarly to Apache's `RequestHeader set X-Forwarded-Proto https`, the X-Forwarded-Proto header with the `$scheme` value, informs the rdiffweb server of the protocol being used.