### PR TITLE
Add huntr.dev to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,3 +3,10 @@
 ## Reporting a Vulnerability
 
 Please report security issues to `info@ikus-soft.com`
+
+
+# Reporting a Vulnerability
+
+If you discover a security vulnerability in rdiffweb please disclose it via [our huntr page](https://huntr.dev/repos/ikus060/rdiffweb/). Bounty eligibility, CVE assignment, response times and past reports are all there.
+
+Thank you for improving the security of rdiffweb.


### PR DESCRIPTION
As requested through the platform by @ikus060, this will point your security policy to [huntr.dev](https://huntr.dev/repos/ikus060/rdiffweb})